### PR TITLE
Deleting `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: monthly
-      time: '13:00'
-    open-pull-requests-limit: 10


### PR DESCRIPTION
Considering the fact that we don't plan on updating our Node version as the learning lab progresses, I think it makes very little sense to keep updating the dependencies - one of them might end up ending support for our version of Node.