### PR TITLE
feat: #22 Graph component

### DIFF
--- a/src/assets/Exercises/graphPoint.svg
+++ b/src/assets/Exercises/graphPoint.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="5" cy="5" r="5" fill="black"/>
+</svg>

--- a/src/assets/Exercises/pointer.svg
+++ b/src/assets/Exercises/pointer.svg
@@ -1,0 +1,3 @@
+<svg width="29" height="24" viewBox="0 0 29 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <polygon points="0,0 29,12 0,24 7,12" fill="black"/>
+</svg>

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -1,8 +1,7 @@
 import '../../styles/ExerciseSide.scss';
 import AxisExercise from './Exercises/AxisExercise';
 import AxisInput from './Exercises/AxisInputs';
-import Graph from './Exercises/Graph';
-('./Exercises/AxisExercise');
+//import Graph from './Exercises/Graph';
 
 function ExerciseSide(): JSX.Element {
   return (

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -19,7 +19,7 @@ function ExerciseSide(): JSX.Element {
           pointerOrientation={45}
         />
 
-        {/*<AxisExercise
+        <AxisExercise
           orientation="horizontal"
           markers={[-2, -1, 0, 1, 2]}
           labels={['A', '', '', 'B', 'C']}

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -1,14 +1,14 @@
 import '../../styles/ExerciseSide.scss';
 import AxisExercise from './Exercises/AxisExercise';
 import AxisInput from './Exercises/AxisInputs';
-import Graph from './Graph';
+import Graph from './Exercises/Graph';
 ('./Exercises/AxisExercise');
 
 function ExerciseSide(): JSX.Element {
   return (
     <section id="exercise-side-container">
       <div className="exercise-box">
-        <Graph
+        {/*<Graph
           origin={{ x: 0, y: 0 }}
           points={[
             { x: -1, y: 1 },
@@ -17,7 +17,7 @@ function ExerciseSide(): JSX.Element {
           labels={['', '']}
           pointerPosition={{ x: 1, y: 1 }}
           pointerOrientation={45}
-        />
+        />*/}
 
         <AxisExercise
           orientation="horizontal"

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -10,8 +10,11 @@ function ExerciseSide(): JSX.Element {
       <div className="exercise-box">
         <Graph
           origin={{ x: 0, y: 0 }}
-          points={[]}
-          labels={[]}
+          points={[
+            { x: -1, y: 1 },
+            { x: 2, y: -1 },
+          ]}
+          labels={['', '']}
           pointerPosition={{ x: 1, y: 1 }}
           pointerOrientation={45}
         />

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -12,8 +12,8 @@ function ExerciseSide(): JSX.Element {
           origin={{ x: 0, y: 0 }}
           points={[]}
           labels={[]}
-          cursorPosition={{ x: 1, y: 2 }}
-          cursorOrientation={0}
+          pointerPosition={{ x: 1, y: 1 }}
+          pointerOrientation={45}
         />
 
         {/*<AxisExercise

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -1,14 +1,22 @@
 import '../../styles/ExerciseSide.scss';
-
 import AxisExercise from './Exercises/AxisExercise';
 import AxisInput from './Exercises/AxisInputs';
+import Graph from './Graph';
 ('./Exercises/AxisExercise');
 
 function ExerciseSide(): JSX.Element {
   return (
     <section id="exercise-side-container">
       <div className="exercise-box">
-        <AxisExercise
+        <Graph
+          origin={{ x: 0, y: 0 }}
+          points={[]}
+          labels={[]}
+          cursorPosition={{ x: 1, y: 2 }}
+          cursorOrientation={0}
+        />
+
+        {/*<AxisExercise
           orientation="horizontal"
           markers={[-2, -1, 0, 1, 2]}
           labels={['A', '', '', 'B', 'C']}

--- a/src/components/shared/Exercises/Graph.tsx
+++ b/src/components/shared/Exercises/Graph.tsx
@@ -1,6 +1,6 @@
-import '../../styles/Graph.scss';
-import GraphPoint from '../../assets/Exercises/graphPoint.svg';
-import Pointer from '../../assets/Exercises/pointer.svg';
+import '../../../styles/Graph.scss';
+import GraphPoint from '../../../assets/Exercises/graphPoint.svg';
+import Pointer from '../../../assets/Exercises/pointer.svg';
 
 interface GraphProps {
   origin: { x: number; y: number };

--- a/src/components/shared/Graph.tsx
+++ b/src/components/shared/Graph.tsx
@@ -1,0 +1,73 @@
+import '../../styles/Graph.scss';
+
+interface GraphProps {
+  points: { x: number; y: number }[];
+  //labels: string[];
+  //cursorPosition: { x: number; y: number };
+  //cursorOrientation: number; //TODO: radians or degrees?
+}
+
+function Graph({
+  points,
+}: //labels,
+//cursorPosition,
+//cursorOrientation,
+GraphProps): JSX.Element {
+  const leftBound = Math.min(-1, ...points.map((p) => Math.floor(p.x)));
+  const rightBound = Math.max(1, ...points.map((p) => Math.ceil(p.x)));
+  const topBound = Math.min(-1, ...points.map((p) => Math.floor(p.y)));
+  const bottomBound = Math.max(1, ...points.map((p) => Math.ceil(p.y)));
+
+  const verticalLineCount = rightBound - leftBound + 1;
+  const horizontalLineCount = bottomBound - topBound + 1;
+  //TODO: make it so the grid is square. Have to draw more than
+  //`verticalLineCount` or `horizontalLineCount` lines depending
+  //on which dimension the points need
+  const lineSpacing = Math.min(
+    100 / horizontalLineCount,
+    100 / verticalLineCount
+  );
+
+  return (
+    <div className="graph-container">
+      {Array(verticalLineCount)
+        .fill(0)
+        .map((_, i) => {
+          return (
+            <div
+              key={i}
+              className="grid-line--vertical"
+              style={{
+                height: '100%',
+                left: `${lineSpacing * (i + 0.5)}%`,
+              }}
+            />
+          );
+        })}
+
+      {Array(horizontalLineCount)
+        .fill(0)
+        .map((_, i) => {
+          return (
+            <div
+              key={i}
+              className="grid-line--horizontal"
+              style={{
+                width: '100%',
+                top: `${lineSpacing * (i + 0.5)}%`,
+              }}
+            />
+          );
+        })}
+
+      {/* {<div className="grid-line--vertical"
+                style={{
+                    height: "100%",
+                    left: `${spaceBetweenVertical}%`
+                }}>
+            </div>} */}
+    </div>
+  );
+}
+
+export default Graph;

--- a/src/components/shared/Graph.tsx
+++ b/src/components/shared/Graph.tsx
@@ -30,7 +30,9 @@ GraphProps): JSX.Element {
           return (
             <div
               key={i}
-              className="grid-line--vertical"
+              className={
+                i == 3 + origin.x ? 'axis-line vertical' : 'grid-line vertical'
+              }
               style={{
                 left: `${verticalLineSpacing * (i + 1)}%`,
               }}
@@ -44,7 +46,11 @@ GraphProps): JSX.Element {
           return (
             <div
               key={i}
-              className="grid-line--horizontal"
+              className={
+                i == 2 - origin.y
+                  ? 'axis-line horizontal'
+                  : 'grid-line horizontal '
+              }
               style={{
                 top: `${horizontalLineSpacing * (i + 0.25)}%`,
               }}

--- a/src/components/shared/Graph.tsx
+++ b/src/components/shared/Graph.tsx
@@ -1,32 +1,26 @@
 import '../../styles/Graph.scss';
 
 interface GraphProps {
+  origin: { x: number; y: number };
   points: { x: number; y: number }[];
-  //labels: string[];
-  //cursorPosition: { x: number; y: number };
-  //cursorOrientation: number; //TODO: radians or degrees?
+  labels: string[];
+  cursorPosition: { x: number; y: number };
+  cursorOrientation: number; //TODO: radians or degrees?
 }
 
 function Graph({
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  origin,
   points,
-}: //labels,
-//cursorPosition,
-//cursorOrientation,
+  labels,
+  cursorPosition,
+  cursorOrientation,
+}: /* eslint-enable @typescript-eslint/no-unused-vars */
 GraphProps): JSX.Element {
-  const leftBound = Math.min(-1, ...points.map((p) => Math.floor(p.x)));
-  const rightBound = Math.max(1, ...points.map((p) => Math.ceil(p.x)));
-  const topBound = Math.min(-1, ...points.map((p) => Math.floor(p.y)));
-  const bottomBound = Math.max(1, ...points.map((p) => Math.ceil(p.y)));
-
-  const verticalLineCount = rightBound - leftBound + 1;
-  const horizontalLineCount = bottomBound - topBound + 1;
-  //TODO: make it so the grid is square. Have to draw more than
-  //`verticalLineCount` or `horizontalLineCount` lines depending
-  //on which dimension the points need
-  const lineSpacing = Math.min(
-    100 / horizontalLineCount,
-    100 / verticalLineCount
-  );
+  const verticalLineCount = 7;
+  const horizontalLineCount = 5;
+  const verticalLineSpacing = 100 / (verticalLineCount + 1);
+  const horizontalLineSpacing = 100 / (horizontalLineCount - 0.5);
 
   return (
     <div className="graph-container">
@@ -38,8 +32,7 @@ GraphProps): JSX.Element {
               key={i}
               className="grid-line--vertical"
               style={{
-                height: '100%',
-                left: `${lineSpacing * (i + 0.5)}%`,
+                left: `${verticalLineSpacing * (i + 1)}%`,
               }}
             />
           );
@@ -53,19 +46,11 @@ GraphProps): JSX.Element {
               key={i}
               className="grid-line--horizontal"
               style={{
-                width: '100%',
-                top: `${lineSpacing * (i + 0.5)}%`,
+                top: `${horizontalLineSpacing * (i + 0.25)}%`,
               }}
             />
           );
         })}
-
-      {/* {<div className="grid-line--vertical"
-                style={{
-                    height: "100%",
-                    left: `${spaceBetweenVertical}%`
-                }}>
-            </div>} */}
     </div>
   );
 }

--- a/src/components/shared/Graph.tsx
+++ b/src/components/shared/Graph.tsx
@@ -1,4 +1,5 @@
 import '../../styles/Graph.scss';
+import GraphPoint from '../../assets/Exercises/graphPoint.svg';
 import Pointer from '../../assets/Exercises/pointer.svg';
 
 interface GraphProps {
@@ -78,6 +79,21 @@ GraphProps): JSX.Element {
           }}
         />
       }
+
+      {points.map((point, i) => {
+        //let label = labels[i];
+        return (
+          <img
+            key={i}
+            className="point"
+            src={GraphPoint}
+            style={{
+              left: `${xPos(4 + origin.x + point.x)}%`,
+              top: `${yPos(2 - origin.y - point.y + 0.25)}%`,
+            }}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/components/shared/Graph.tsx
+++ b/src/components/shared/Graph.tsx
@@ -1,11 +1,12 @@
 import '../../styles/Graph.scss';
+import Pointer from '../../assets/Exercises/pointer.svg';
 
 interface GraphProps {
   origin: { x: number; y: number };
   points: { x: number; y: number }[];
   labels: string[];
-  cursorPosition: { x: number; y: number };
-  cursorOrientation: number; //TODO: radians or degrees?
+  pointerPosition: { x: number; y: number };
+  pointerOrientation: number; //TODO: radians or degrees?
 }
 
 function Graph({
@@ -13,14 +14,22 @@ function Graph({
   origin,
   points,
   labels,
-  cursorPosition,
-  cursorOrientation,
+  pointerPosition,
+  pointerOrientation,
 }: /* eslint-enable @typescript-eslint/no-unused-vars */
 GraphProps): JSX.Element {
   const verticalLineCount = 7;
   const horizontalLineCount = 5;
   const verticalLineSpacing = 100 / (verticalLineCount + 1);
   const horizontalLineSpacing = 100 / (horizontalLineCount - 0.5);
+
+  function xPos(lines: number): number {
+    return verticalLineSpacing * lines;
+  }
+
+  function yPos(lines: number): number {
+    return horizontalLineSpacing * lines;
+  }
 
   return (
     <div className="graph-container">
@@ -34,7 +43,7 @@ GraphProps): JSX.Element {
                 i == 3 + origin.x ? 'axis-line vertical' : 'grid-line vertical'
               }
               style={{
-                left: `${verticalLineSpacing * (i + 1)}%`,
+                left: `${xPos(i + 1)}%`,
               }}
             />
           );
@@ -49,14 +58,26 @@ GraphProps): JSX.Element {
               className={
                 i == 2 - origin.y
                   ? 'axis-line horizontal'
-                  : 'grid-line horizontal '
+                  : 'grid-line horizontal'
               }
               style={{
-                top: `${horizontalLineSpacing * (i + 0.25)}%`,
+                top: `${yPos(i + 0.25)}%`,
               }}
             />
           );
         })}
+
+      {
+        <img
+          className="pointer"
+          src={Pointer}
+          style={{
+            transform: `translate(-50%, -50%) rotate(${-pointerOrientation}deg)`,
+            left: `${xPos(4 + origin.x + pointerPosition.x)}%`,
+            top: `${yPos(2 - origin.y - pointerPosition.y + 0.25)}%`,
+          }}
+        />
+      }
     </div>
   );
 }

--- a/src/styles/Graph.scss
+++ b/src/styles/Graph.scss
@@ -28,3 +28,8 @@
   height: 0;
   width: 100%;
 }
+
+.pointer {
+  position: absolute;
+  z-index: 2;
+}

--- a/src/styles/Graph.scss
+++ b/src/styles/Graph.scss
@@ -1,0 +1,23 @@
+.graph-container {
+  width: 300px;
+  height: 100px;
+  border: solid 2px #000;
+  border-radius: 12px;
+  position: absolute;
+}
+
+.grid-line {
+  background-color: #000;
+  outline: calc(1px + 0.05vw) solid #c2c2c2;
+  position: absolute;
+
+  &--vertical {
+    @extend .grid-line;
+    width: 0;
+  }
+
+  &--horizontal {
+    @extend .grid-line;
+    height: 0;
+  }
+}

--- a/src/styles/Graph.scss
+++ b/src/styles/Graph.scss
@@ -8,19 +8,23 @@
   width: 40%;
 }
 
-%grid-line {
+.grid-line {
   outline: 1px solid #c2c2c2;
   position: absolute;
 }
 
-.grid-line--vertical {
-  @extend %grid-line;
+.axis-line {
+  outline: 2px solid #31a19b;
+  position: absolute;
+  z-index: 1;
+}
+
+.vertical {
   height: 100%;
   width: 0;
 }
 
-.grid-line--horizontal {
-  @extend %grid-line;
+.horizontal {
   height: 0;
-  width: 100%
+  width: 100%;
 }

--- a/src/styles/Graph.scss
+++ b/src/styles/Graph.scss
@@ -33,3 +33,9 @@
   position: absolute;
   z-index: 2;
 }
+
+.point {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+}

--- a/src/styles/Graph.scss
+++ b/src/styles/Graph.scss
@@ -1,23 +1,26 @@
 .graph-container {
-  width: 300px;
-  height: 100px;
   border: solid 2px #000;
   border-radius: 12px;
+  height: 0;
+  padding-bottom: 22.5%;
+  position: absolute;
+  top: 5%;
+  width: 40%;
+}
+
+%grid-line {
+  outline: 1px solid #c2c2c2;
   position: absolute;
 }
 
-.grid-line {
-  background-color: #000;
-  outline: calc(1px + 0.05vw) solid #c2c2c2;
-  position: absolute;
+.grid-line--vertical {
+  @extend %grid-line;
+  height: 100%;
+  width: 0;
+}
 
-  &--vertical {
-    @extend .grid-line;
-    width: 0;
-  }
-
-  &--horizontal {
-    @extend .grid-line;
-    height: 0;
-  }
+.grid-line--horizontal {
+  @extend %grid-line;
+  height: 0;
+  width: 100%
 }


### PR DESCRIPTION
## Summary

Closes #22

Created a new `Graph` component with grid lines and a pointer and points. Added svg assets for the pointer and points. The following are customizable through the `GraphProps` argument:
* `origin` (where the x- and y-axes intersect) - positions of the points and pointer are relative to this origin, not to the center of the graph.
* `points` on the graph
* pointer (the arrow-shaped "turtle") - customizable position and orientation.

Note the graph has a constant number of grid lines - based on the Figma mockup this doesn't need to be customizable and moving the origin around should be enough.

## Test Plan
Manually tested the Graph component by placing it in the `ExerciseSide`. Changing the values in `GraphProps` changed the visuals properly. Tested different window sizes to ensure the component is responsive.
![image](https://user-images.githubusercontent.com/28466971/213077046-7a2d5a3f-8c9b-40e4-9a5a-e60f032558c2.png)