### PR TITLE
feat: connect axis input to axis exercise under parent element

### DIFF
--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -29,8 +29,14 @@ function ExerciseSide(): JSX.Element {
         /> */}
 
         <AxisParent
-          axisMarkers={[[-2, -1, 0, 1, 2], [-1, 0, 1, 2]]}
-          axisLabels={[['A', '', '', 'B', 'C'], ['A', '', '', 'B']]}
+          axisMarkers={[
+            [-2, -1, 0, 1, 2],
+            [-1, 0, 1, 2],
+          ]}
+          axisLabels={[
+            ['A', '', '', 'B', 'C'],
+            ['A', '', '', 'B'],
+          ]}
         />
       </div>
     </section>

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -1,32 +1,19 @@
 import '../../styles/ExerciseSide.scss';
-import AxisExercise from './Exercises/AxisExercise';
-import AxisInput from './Exercises/AxisInputs';
-//import ExerciseComplete from './Exercises/ExerciseComplete';
-//import Graph from './Exercises/Graph';
+
+import AxisParent from './Exercises/AxisParent';
+('./Exercises/AxisExercise');
 
 function ExerciseSide(): JSX.Element {
   return (
     <section id="exercise-side-container">
       <div className="exercise-box">
-        {/*<Graph
-          origin={{ x: 0, y: 0 }}
-          points={[
-            { x: -1, y: 1 },
-            { x: 2, y: -1 },
-          ]}
-          labels={['', '']}
-          pointerPosition={{ x: 1, y: 1 }}
-          pointerOrientation={45}
-        />*/}
-        <AxisExercise
+        {/* <AxisExercise
           orientation="horizontal"
           markers={[-2, -1, 0, 1, 2]}
           labels={['A', '', '', 'B', 'C']}
           turtlePosition={1}
         />
-        <p className="instruction">
-          Type the correct numbers into the blanks below!
-        </p>
+
         <AxisInput
           questionLabels={[
             ['a', 'b', 'c'],
@@ -39,6 +26,11 @@ function ExerciseSide(): JSX.Element {
             [4, 5],
           ]}
           setIsComplete={alert}
+        /> */}
+
+        <AxisParent
+          axisMarkers={[[-2, -1, 0, 1, 2], [-1, 0, 1, 2]]}
+          axisLabels={[['A', '', '', 'B', 'C'], ['A', '', '', 'B']]}
         />
       </div>
     </section>

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -1,46 +1,37 @@
+import { useState } from 'react';
 import '../../styles/ExerciseSide.scss';
 
+//import AxisExercise from './Exercises/AxisExercise';
+//import AxisInput from './Exercises/AxisInputs';
 import AxisParent from './Exercises/AxisParent';
 ('./Exercises/AxisExercise');
 
 function ExerciseSide(): JSX.Element {
-  return (
-    <section id="exercise-side-container">
-      <div className="exercise-box">
-        {/* <AxisExercise
-          orientation="horizontal"
-          markers={[-2, -1, 0, 1, 2]}
-          labels={['A', '', '', 'B', 'C']}
-          turtlePosition={1}
-        />
+  const [exerciseNum, setExerciseNum] = useState(0); //indicates switch from axis input to unit circle exercise
 
-        <AxisInput
-          questionLabels={[
-            ['a', 'b', 'c'],
-            ['Hi!', 'bye!', '4', '43'],
-            ['e', 'f'],
-          ]}
-          answers={[
-            [2, 2, 1],
-            [1, 4, 5, 6],
-            [4, 5],
-          ]}
-          setIsComplete={alert}
-        /> */}
-
-        <AxisParent
-          axisMarkers={[
-            [-2, -1, 0, 1, 2],
-            [-1, 0, 1, 2],
-          ]}
-          axisLabels={[
-            ['A', '', '', 'B', 'C'],
-            ['A', '', '', 'B'],
-          ]}
-        />
-      </div>
-    </section>
-  );
+  function changeExercise() {
+    setExerciseNum(exerciseNum + 1);
+  }
+  if (exerciseNum == 0)
+    return (
+      <section id="exercise-side-container">
+        <div className="exercise-box">
+          <AxisParent
+            axisMarkers={[
+              [-2, -1, 0, 1, 2],
+              [-1, 0, 1, 2],
+            ]}
+            axisLabels={[
+              ['A', '', '', 'B', 'C'],
+              ['A', '', '', 'B'],
+            ]}
+            toNextExercise={changeExercise}
+          />
+          <p>exercise {exerciseNum}</p>
+        </div>
+      </section>
+    );
+  else return <p>exercise {exerciseNum}</p>;
 }
 
 export default ExerciseSide;

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -29,14 +29,8 @@ function ExerciseSide(): JSX.Element {
         /> */}
 
         <AxisParent
-          axisMarkers={[
-            [-2, -1, 0, 1, 2],
-            [-1, 0, 1, 2],
-          ]}
-          axisLabels={[
-            ['A', '', '', 'B', 'C'],
-            ['A', '', '', 'B'],
-          ]}
+          axisMarkers={[[-2, -1, 0, 1, 2], [-1, 0, 1, 2]]}
+          axisLabels={[['A', '', '', 'B', 'C'], ['A', '', '', 'B']]}
         />
       </div>
     </section>

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import '../../styles/ExerciseSide.scss';
 
 //import AxisExercise from './Exercises/AxisExercise';
@@ -7,31 +6,23 @@ import AxisParent from './Exercises/AxisParent';
 ('./Exercises/AxisExercise');
 
 function ExerciseSide(): JSX.Element {
-  const [exerciseNum, setExerciseNum] = useState(0); //indicates switch from axis input to unit circle exercise
-
-  function changeExercise() {
-    setExerciseNum(exerciseNum + 1);
-  }
-  if (exerciseNum == 0)
-    return (
-      <section id="exercise-side-container">
-        <div className="exercise-box">
-          <AxisParent
-            axisMarkers={[
-              [-2, -1, 0, 1, 2],
-              [-1, 0, 1, 2],
-            ]}
-            axisLabels={[
-              ['A', '', '', 'B', 'C'],
-              ['A', '', '', 'B'],
-            ]}
-            toNextExercise={changeExercise}
-          />
-          <p>exercise {exerciseNum}</p>
-        </div>
-      </section>
-    );
-  else return <p>exercise {exerciseNum}</p>;
+  return (
+    <section id="exercise-side-container">
+      <div className="exercise-box">
+        <AxisParent
+          axisMarkers={[
+            [-2, -1, 0, 1, 2],
+            [-1, 0, 1, 2],
+          ]}
+          axisLabels={[
+            ['A', '', '', 'B', 'C'],
+            ['A', '', '', 'B'],
+          ]}
+          toNextExercise={() => {return;}}
+        />
+      </div>
+    </section>
+  );
 }
 
 export default ExerciseSide;

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -18,7 +18,9 @@ function ExerciseSide(): JSX.Element {
             ['A', '', '', 'B', 'C'],
             ['A', '', '', 'B'],
           ]}
-          toNextExercise={() => {return;}}
+          toNextExercise={() => {
+            return;
+          }}
         />
       </div>
     </section>

--- a/src/components/shared/Exercises/AxisExercise.tsx
+++ b/src/components/shared/Exercises/AxisExercise.tsx
@@ -42,7 +42,8 @@ function AxisExercise({
                   src={Turtle}
                   alt="turtle-icon"
                   style={{
-                    transform: `rotate(${orientation === 'horizontal' ? '0deg' : '270deg'
+                    transform: `rotate(${
+                      orientation === 'horizontal' ? '0deg' : '270deg'
                     })`,
                   }}
                 />
@@ -51,7 +52,8 @@ function AxisExercise({
             <div // marker label (A, B, C, ...)
               className="marker-label"
               style={{
-                transform: `rotate(${orientation === 'horizontal' ? '0deg' : '270deg'
+                transform: `rotate(${
+                  orientation === 'horizontal' ? '0deg' : '270deg'
                 })`,
               }}
             >
@@ -67,7 +69,8 @@ function AxisExercise({
               <div // marker position
                 className="marker-pos"
                 style={{
-                  transform: `rotate(${orientation === 'horizontal' ? '0deg' : '270deg'
+                  transform: `rotate(${
+                    orientation === 'horizontal' ? '0deg' : '270deg'
                   })`,
                   top: `${pos === 0 ? 90 : 75}%`, // shifting 0 downwards
                   fontSize: `${pos === 0 ? 2 : 1.5}rem`, // sizing fonts for numbers

--- a/src/components/shared/Exercises/AxisExercise.tsx
+++ b/src/components/shared/Exercises/AxisExercise.tsx
@@ -26,6 +26,7 @@ function AxisExercise({
       <img className="axis-img" src={Axis} alt="single-axis" />
       {markers.map((pos, idx) => {
         // map markers and corresponding labels onto axis
+
         const leftPosition = 45 + markerSpacing * pos; // calculate position for marker
         return (
           <div
@@ -41,8 +42,7 @@ function AxisExercise({
                   src={Turtle}
                   alt="turtle-icon"
                   style={{
-                    transform: `rotate(${
-                      orientation === 'horizontal' ? '0deg' : '270deg'
+                    transform: `rotate(${orientation === 'horizontal' ? '0deg' : '270deg'
                     })`,
                   }}
                 />
@@ -51,8 +51,7 @@ function AxisExercise({
             <div // marker label (A, B, C, ...)
               className="marker-label"
               style={{
-                transform: `rotate(${
-                  orientation === 'horizontal' ? '0deg' : '270deg'
+                transform: `rotate(${orientation === 'horizontal' ? '0deg' : '270deg'
                 })`,
               }}
             >
@@ -68,8 +67,7 @@ function AxisExercise({
               <div // marker position
                 className="marker-pos"
                 style={{
-                  transform: `rotate(${
-                    orientation === 'horizontal' ? '0deg' : '270deg'
+                  transform: `rotate(${orientation === 'horizontal' ? '0deg' : '270deg'
                   })`,
                   top: `${pos === 0 ? 90 : 75}%`, // shifting 0 downwards
                   fontSize: `${pos === 0 ? 2 : 1.5}rem`, // sizing fonts for numbers

--- a/src/components/shared/Exercises/AxisInputs.tsx
+++ b/src/components/shared/Exercises/AxisInputs.tsx
@@ -18,7 +18,7 @@ function AxisInput({
   questionLabels,
   answers,
   setIsComplete,
-  nextExercise
+  nextExercise,
 }: AxisInputProps): JSX.Element {
   function MakeQuestion({ label, id }: AxisQuestion): JSX.Element {
     const handleChange = (event: { target: { value: string } }) => {

--- a/src/components/shared/Exercises/AxisInputs.tsx
+++ b/src/components/shared/Exercises/AxisInputs.tsx
@@ -5,6 +5,7 @@ interface AxisInputProps {
   questionLabels: string[][];
   answers: number[][];
   setIsComplete: (a: boolean) => void;
+  nextExercise: () => void;
 }
 
 interface AxisQuestion {
@@ -17,6 +18,7 @@ function AxisInput({
   questionLabels,
   answers,
   setIsComplete,
+  nextExercise
 }: AxisInputProps): JSX.Element {
   function MakeQuestion({ label, id }: AxisQuestion): JSX.Element {
     const handleChange = (event: { target: { value: string } }) => {
@@ -51,6 +53,7 @@ function AxisInput({
     setCounter(counter + 1);
     setWrong(false);
     setInputText(startInputStrings);
+    nextExercise();
   }
 
   function wrongMessage(isWrong: boolean) {

--- a/src/components/shared/Exercises/AxisInputs.tsx
+++ b/src/components/shared/Exercises/AxisInputs.tsx
@@ -48,6 +48,7 @@ function AxisInput({
     if (counter == questionLabels.length - 1) {
       setIsDone(true);
       setIsComplete(true);
+      nextExercise();
       return;
     }
     setCounter(counter + 1);

--- a/src/components/shared/Exercises/AxisParent.tsx
+++ b/src/components/shared/Exercises/AxisParent.tsx
@@ -1,0 +1,60 @@
+import '../../../styles/Exercises/AxisExercise.scss';
+import AxisExercise from './AxisExercise';
+import AxisInput from './AxisInputs';
+('./Exercises/AxisExercise');
+
+interface AxisParentProps {
+  axisMarkers: number[][]; //2-D array for different sets of problems
+  axisLabels: string[][];
+}
+
+/*
+interface AxisInputProps {
+  questionLabels: string[][];
+  answers: number[][];
+  setIsComplete: (a: boolean) => void;
+}
+
+interface AxisQuestion {
+  label: string;
+  answer: number; // Should change to being strings
+  id: number; //This sucks lol
+}
+*/
+
+function AxisParent({ axisMarkers, axisLabels }: AxisParentProps): JSX.Element {
+  //make 2d array for answers using the non-empty elements of axisLabels
+  const axisAnswers: number[][] = [];
+  const questionLabels: string[][] = [];
+  for (let i = 0; i < axisMarkers.length; i++) {
+    const currentAnswers = [];
+    const currentLabels = [];
+    const length = axisMarkers[i].length;
+    for (let j = 0; j < length; j++) {
+      if (axisLabels[i][j] !== '') {
+        currentAnswers.push(axisMarkers[i][j]);
+        currentLabels.push(axisLabels[i][j]);
+      }
+    }
+    axisAnswers.push(currentAnswers);
+    questionLabels.push(currentLabels);
+  }
+
+  return (
+    <div>
+      <AxisExercise
+        orientation="horizontal"
+        markers={axisMarkers[0]}
+        labels={axisLabels[0]}
+        turtlePosition={1}
+      />
+      <AxisInput
+        questionLabels={questionLabels}
+        answers={axisAnswers}
+        setIsComplete={alert}
+      />
+    </div>
+  );
+}
+
+export default AxisParent;

--- a/src/components/shared/Exercises/AxisParent.tsx
+++ b/src/components/shared/Exercises/AxisParent.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import '../../../styles/Exercises/AxisExercise.scss';
 import AxisExercise from './AxisExercise';
 import AxisInput from './AxisInputs';
@@ -7,6 +7,7 @@ import AxisInput from './AxisInputs';
 interface AxisParentProps {
   axisMarkers: number[][]; //2-D array for different sets of problems
   axisLabels: string[][];
+  toNextExercise: () => void;
 }
 
 /*
@@ -23,7 +24,11 @@ interface AxisQuestion {
 }
 */
 
-function AxisParent({ axisMarkers, axisLabels }: AxisParentProps): JSX.Element {
+function AxisParent({
+  axisMarkers,
+  axisLabels,
+  toNextExercise,
+}: AxisParentProps): JSX.Element {
   //make 2d array for answers using the non-empty elements of axisLabels
   const axisAnswers: number[][] = [];
   const questionLabels: string[][] = [];
@@ -44,13 +49,20 @@ function AxisParent({ axisMarkers, axisLabels }: AxisParentProps): JSX.Element {
   const [exerciseNum, setExerciseNum] = useState(0);
   function nextExercise() {
     setExerciseNum(exerciseNum + 1);
-  }
+  } // advance to next exercise within axis inputs exercise
+
+  useEffect(() => {
+    if (exerciseNum == axisMarkers.length) {
+      toNextExercise(); // update parent exercise side that axis input exercise is complete
+    }
+  });
+
   return (
     <div>
       <AxisExercise
         orientation="horizontal"
-        markers={axisMarkers[exerciseNum]}
-        labels={axisLabels[exerciseNum]}
+        markers={axisMarkers[Math.min(exerciseNum, axisMarkers.length - 1)]}
+        labels={axisLabels[Math.min(exerciseNum, axisLabels.length - 1)]}
         turtlePosition={1}
       />
       <AxisInput

--- a/src/components/shared/Exercises/AxisParent.tsx
+++ b/src/components/shared/Exercises/AxisParent.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import '../../../styles/Exercises/AxisExercise.scss';
 import AxisExercise from './AxisExercise';
 import AxisInput from './AxisInputs';
@@ -40,17 +41,22 @@ function AxisParent({ axisMarkers, axisLabels }: AxisParentProps): JSX.Element {
     questionLabels.push(currentLabels);
   }
 
+  const [exerciseNum, setExerciseNum] = useState(0);
+  function nextExercise() {
+    setExerciseNum(exerciseNum + 1);
+  }
   return (
     <div>
       <AxisExercise
         orientation="horizontal"
-        markers={axisMarkers[0]}
-        labels={axisLabels[0]}
+        markers={axisMarkers[exerciseNum]}
+        labels={axisLabels[exerciseNum]}
         turtlePosition={1}
       />
       <AxisInput
         questionLabels={questionLabels}
         answers={axisAnswers}
+        nextExercise={nextExercise}
         setIsComplete={alert}
       />
     </div>


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change (feat, fix, refactor)
    E.g. "fix: fix activity 1 button placement" or "feat: add favicon and make footer thinner"
-->

## Summary

Closes #32<!-- issue number -->

<!-- Enumerate changes you made and why you made them -->
* Added new axis parent component to encompass axis input and axis exercise
* Added function inside axis parent to keep track of answers based on one set of axis labels
* Added state for axis parent to indicate to parent that axis exercise is complete
<!-- list any new dependencies required for this change -->

## Test Plan

<!--
    How did you manually test your change? How do you know that your code works?
    Add supporting screenshots of the feature in play, terminal pastes, etc. as necessary
-->
* Tested in browser that answer submission still works
* Rendered in parent the exercise number (0 or axis exercise, 1 for next) to check axis parent correctly reports completion of axis exercise 
