### PR TITLE
feat: add logic to switch between exercises upon completion on exercise side

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,10 +6,10 @@ import '../assets/WestwoodSans-Regular.ttf';
 
 function App(): JSX.Element {
   const [exerciseCount, setExerciseCount] = useState(0);
-  if(exerciseCount == 1){
+  if (exerciseCount == 2) {
     return (
       <main>
-        <CongratsPage/>
+        <CongratsPage />
       </main>
     );
   }
@@ -17,7 +17,9 @@ function App(): JSX.Element {
     <div>
       <main>
         <LessonSide />
-        <ExerciseSide incrementExercise={() => setExerciseCount(exerciseCount + 1)}/>
+        <ExerciseSide
+          incrementExercise={() => setExerciseCount(exerciseCount + 1)}
+        />
       </main>
     </div>
   );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,13 +1,23 @@
+import { useState } from 'react';
+import CongratsPage from './shared/Congratulations';
 import ExerciseSide from './shared/ExerciseSide';
 import LessonSide from './shared/LessonSide';
 import '../assets/WestwoodSans-Regular.ttf';
 
 function App(): JSX.Element {
+  const [exerciseCount, setExerciseCount] = useState(0);
+  if(exerciseCount == 1){
+    return (
+      <main>
+        <CongratsPage/>
+      </main>
+    );
+  }
   return (
     <div>
       <main>
         <LessonSide />
-        <ExerciseSide />
+        <ExerciseSide incrementExercise={() => setExerciseCount(exerciseCount + 1)}/>
       </main>
     </div>
   );

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -3,11 +3,15 @@ import '../../styles/ExerciseSide.scss';
 
 //import AxisExercise from './Exercises/AxisExercise';
 //import AxisInput from './Exercises/AxisInputs';
-import CongratsPage from './Congratulations';
 import AxisParent from './Exercises/AxisParent';
+import UnitCircleExercise from './Exercises/UnitCircleExercise';
 ('./Exercises/AxisExercise');
 
-function ExerciseSide(): JSX.Element {
+interface ExerciseSideProps {
+  incrementExercise: () => void;
+}
+
+function ExerciseSide({incrementExercise}: ExerciseSideProps): JSX.Element {
   const [completeExercises, setCompleteExercises] = useState(0);
   type availableExercises = 'axis' | 'congrats';
 
@@ -29,6 +33,7 @@ function ExerciseSide(): JSX.Element {
             ]}
             toNextExercise={() => {
               setCompleteExercises(completeExercises + 1);
+              incrementExercise();
               return;
             }}
           />
@@ -36,10 +41,15 @@ function ExerciseSide(): JSX.Element {
       </section>
     );
   } else if (exercises[completeExercises] === 'congrats') {
-    curExercise = <CongratsPage></CongratsPage>;
+    curExercise = <UnitCircleExercise turtleAngle={1} markers={['A','','B']} labels={['B','C','D']}/>;
   }
 
-  return <div>{curExercise}</div>;
+  return (
+    <section id="exercise-side-container">
+      <div className="exercise-box">
+        {curExercise}
+      </div>
+    </section>);
 }
 
 export default ExerciseSide;

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -1,30 +1,45 @@
+import { useState } from 'react';
 import '../../styles/ExerciseSide.scss';
 
 //import AxisExercise from './Exercises/AxisExercise';
 //import AxisInput from './Exercises/AxisInputs';
+import CongratsPage from './Congratulations';
 import AxisParent from './Exercises/AxisParent';
 ('./Exercises/AxisExercise');
 
 function ExerciseSide(): JSX.Element {
-  return (
-    <section id="exercise-side-container">
-      <div className="exercise-box">
-        <AxisParent
-          axisMarkers={[
-            [-2, -1, 0, 1, 2],
-            [-1, 0, 1, 2],
-          ]}
-          axisLabels={[
-            ['A', '', '', 'B', 'C'],
-            ['A', '', '', 'B'],
-          ]}
-          toNextExercise={() => {
-            return;
-          }}
-        />
-      </div>
-    </section>
-  );
+  const [completeExercises, setCompleteExercises] = useState(0);
+  type availableExercises = 'axis' | 'congrats';
+
+  const exercises: availableExercises[] = ['axis', 'congrats'];
+  let curExercise;
+
+  if (exercises[completeExercises] == 'axis') {
+    curExercise = (
+      <section id="exercise-side-container">
+        <div className="exercise-box">
+          <AxisParent
+            axisMarkers={[
+              [-2, -1, 0, 1, 2],
+              [-1, 0, 1, 2],
+            ]}
+            axisLabels={[
+              ['A', '', '', 'B', 'C'],
+              ['A', '', '', 'B'],
+            ]}
+            toNextExercise={() => {
+              setCompleteExercises(completeExercises + 1);
+              return;
+            }}
+          />
+        </div>
+      </section>
+    );
+  } else if (exercises[completeExercises] === 'congrats') {
+    curExercise = <CongratsPage></CongratsPage>;
+  }
+
+  return <div>{curExercise}</div>;
 }
 
 export default ExerciseSide;

--- a/src/components/shared/ExerciseSide.tsx
+++ b/src/components/shared/ExerciseSide.tsx
@@ -11,11 +11,11 @@ interface ExerciseSideProps {
   incrementExercise: () => void;
 }
 
-function ExerciseSide({incrementExercise}: ExerciseSideProps): JSX.Element {
+function ExerciseSide({ incrementExercise }: ExerciseSideProps): JSX.Element {
   const [completeExercises, setCompleteExercises] = useState(0);
-  type availableExercises = 'axis' | 'congrats';
+  type availableExercises = 'axis' | 'congrats' | 'circle';
 
-  const exercises: availableExercises[] = ['axis', 'congrats'];
+  const exercises: availableExercises[] = ['axis', 'circle', 'congrats'];
   let curExercise;
 
   if (exercises[completeExercises] == 'axis') {
@@ -40,16 +40,21 @@ function ExerciseSide({incrementExercise}: ExerciseSideProps): JSX.Element {
         </div>
       </section>
     );
-  } else if (exercises[completeExercises] === 'congrats') {
-    curExercise = <UnitCircleExercise turtleAngle={1} markers={['A','','B']} labels={['B','C','D']}/>;
+  } else if (exercises[completeExercises] === 'circle') {
+    curExercise = (
+      <UnitCircleExercise
+        turtleAngle={1}
+        markers={['A', '', 'B']}
+        labels={['B', 'C', 'D']}
+      />
+    );
   }
 
   return (
     <section id="exercise-side-container">
-      <div className="exercise-box">
-        {curExercise}
-      </div>
-    </section>);
+      <div className="exercise-box">{curExercise}</div>
+    </section>
+  );
 }
 
 export default ExerciseSide;

--- a/src/components/shared/Exercises/AxisInputs.tsx
+++ b/src/components/shared/Exercises/AxisInputs.tsx
@@ -4,7 +4,6 @@ import '../../../styles/Exercises/AxisInput.scss';
 interface AxisInputProps {
   questionLabels: string[][];
   answers: number[][];
-  setIsComplete: (a: boolean) => void;
   nextExercise: () => void;
 }
 
@@ -17,7 +16,6 @@ interface AxisQuestion {
 function AxisInput({
   questionLabels,
   answers,
-  setIsComplete,
   nextExercise,
 }: AxisInputProps): JSX.Element {
   function MakeQuestion({ label, id }: AxisQuestion): JSX.Element {
@@ -47,7 +45,7 @@ function AxisInput({
     }
     if (counter == questionLabels.length - 1) {
       setIsDone(true);
-      setIsComplete(true);
+      //setIsComplete(true);
       nextExercise();
       return;
     }

--- a/src/components/shared/Exercises/AxisParent.tsx
+++ b/src/components/shared/Exercises/AxisParent.tsx
@@ -69,7 +69,6 @@ function AxisParent({
         questionLabels={questionLabels}
         answers={axisAnswers}
         nextExercise={nextExercise}
-        setIsComplete={alert}
       />
     </div>
   );


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change (feat, fix, refactor)
    E.g. "fix: fix activity 1 button placement" or "feat: add favicon and make footer thinner"
-->

## Summary

Closes #39<!-- issue number -->

<!-- Enumerate changes you made and why you made them -->
<!-- list any new dependencies required for this change -->
* added completeExercises state in AxisExercise for transition between exercise sets (axis, circle) upon completion
* added toNextExercise prop to AxisParent to increment completeExercises upon completion

## Test Plan

<!--
    How did you manually test your change? How do you know that your code works?
    Add supporting screenshots of the feature in play, terminal pastes, etc. as necessary
-->
* tested that exercise switches from axis exercise to circle exercise upon completion of axis exercise 
