### PR TITLE
Feat: Level Selector Dashes Visibility

### DIFF
--- a/src/components/shared/LessonSide/LevelSelector.tsx
+++ b/src/components/shared/LessonSide/LevelSelector.tsx
@@ -43,7 +43,7 @@ function LevelSelector({
                 <div
                   className="level-connector"
                   style={{
-                    visibility: level < 6 ? 'visible' : 'hidden',
+                    visibility: level < maxLevelReached ? 'visible' : 'hidden',
                   }}
                 ></div>
               );


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change (feat, fix, refactor)
    E.g. "fix: fix activity 1 button placement" or "feat: add favicon and make footer thinner"
-->

## Summary

Closes #89 <!-- issue number -->

The dash between levels only appears after the level has been unlocked

## Test Plan

A very small change, built on something I've worked on last week
Used yarn start to run and test

<!--
    How did you manually test your change? How do you know that your code works?
    Add supporting screenshots of the feature in play, terminal pastes, etc. as necessary
-->
