### PR TITLE
135 minor update remove stray goto from input field on level 4 (+141 stray text)

### DIFF
--- a/src/components/shared/Exercises/GraphInput.tsx
+++ b/src/components/shared/Exercises/GraphInput.tsx
@@ -1,5 +1,5 @@
 //import { useState } from 'react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import '../../../styles/Exercises/GraphInput.scss';
 
 interface GraphQuestionData {
@@ -33,6 +33,13 @@ function GraphStringElement({
   questionData,
   setCorrect,
 }: GraphQuestionGrouping) {
+  const [inputText, setInputText] = useState("");
+
+  // reset input when questionData changes (new level/question set)
+  useEffect(() => {
+    setInputText(""); 
+  }, [questionData]);
+
   if (questionData.type == 'text') {
     return <p id="graphinput-check-question">{questionData?.text ?? ''}</p>;
   } else {
@@ -45,13 +52,14 @@ function GraphStringElement({
       } else {
         setCorrect(questionData?.id ?? -1, false);
       }
-      //setInputText(event.target.value);
+      setInputText(event.target.value);
     };
     return (
       <div>
         <input
           type="text"
           className="graphinput-check-box"
+          value={inputText}
           style={{ width: `${(questionData?.width ?? 3) * 16}px` }}
           onChange={handleChange}
         />

--- a/src/components/shared/Exercises/GraphInput.tsx
+++ b/src/components/shared/Exercises/GraphInput.tsx
@@ -33,11 +33,11 @@ function GraphStringElement({
   questionData,
   setCorrect,
 }: GraphQuestionGrouping) {
-  const [inputText, setInputText] = useState("");
+  const [inputText, setInputText] = useState('');
 
   // reset input when questionData changes (new level/question set)
   useEffect(() => {
-    setInputText(""); 
+    setInputText('');
   }, [questionData]);
 
   if (questionData.type == 'text') {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change (feat, fix, refactor)
    E.g. "fix: fix activity 1 button placement" or "feat: add favicon and make footer thinner"
-->

## Summary

Closes #135 and #141 

Mostly worked in GraphInput.tsx, modifying GraphStringElement. Added a const input that is passed to the input elements as the value. Every time the QuestionArray changes, the input for GraphStringElement is cleared. This also fixed the problem for Level 5's stray text. 

## Test Plan
I went through each level to make sure that this fixes the stray, pre-filled in text, and it doesn't look like this interferes with any other features. 
<!--
    How did you manually test your change? How do you know that your code works?
    Add supporting screenshots of the feature in play, terminal pastes, etc. as necessary
-->

![image](https://github.com/user-attachments/assets/9f19c166-b314-481f-a5a6-4a08c5639869)
![image](https://github.com/user-attachments/assets/b5cea2b3-85ba-4550-903c-bbcf7e0e39cd)

